### PR TITLE
[매장정보] #18 매장정보 페이지 초기 레이아웃

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,11 +70,11 @@
       }
     },
     "@ant-design/colors": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-3.2.2.tgz",
-      "integrity": "sha512-YKgNbG2dlzqMhA9NtI3/pbY16m3Yl/EeWBRa+lB1X1YaYxHrxNexiQYCLTWO/uDvAjLFMEDU+zR901waBtMtjQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-5.0.0.tgz",
+      "integrity": "sha512-Pe1rYorgVC1v4f+InDXvIlQH715pO1g7BsOhy/ehX/U6ebPKqojmkYJKU3lF+84Zmvyar7ngZ28hesAa1nWjLg==",
       "requires": {
-        "tinycolor2": "^1.4.1"
+        "@ctrl/tinycolor": "^3.1.6"
       }
     },
     "@ant-design/css-animation": {
@@ -83,15 +83,35 @@
       "integrity": "sha512-bvVOe7A+r7lws58B7r+fgnQDK90cV45AXuvGx6i5CCSX1W/M3AJnHsNggDANBxEtWdNdFWcDd5LorB+RdSIlBw=="
     },
     "@ant-design/icons": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.1.0.tgz",
-      "integrity": "sha512-R1aIPJboGq4nVYwW7s0v/V2g6yiY27Kec5ldfK3mWHskw7bihPOKwxkHbITuSJcVNJsSvA6LNMlKZoY1u8DIKQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-4.3.0.tgz",
+      "integrity": "sha512-UoIbw4oz/L/msbkgqs2nls2KP7XNKScOxVR54wRrWwnXOzJaGNwwSdYjHQz+5ETf8C53YPpzMOnRX99LFCdeIQ==",
       "requires": {
-        "@ant-design/colors": "^3.1.0",
+        "@ant-design/colors": "^5.0.0",
         "@ant-design/icons-svg": "^4.0.0",
+        "@babel/runtime": "^7.11.2",
         "classnames": "^2.2.6",
         "insert-css": "^2.0.0",
-        "rc-util": "^4.9.0"
+        "rc-util": "^5.0.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "rc-util": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.5.0.tgz",
+          "integrity": "sha512-YJB+zZGvCll/bhxXRVLAekr7lOvTgqMlRIhgINoINfUek7wQvi5sft46NOi3yYUYhocpuW4k8+5okW46sBsZAQ==",
+          "requires": {
+            "react-is": "^16.12.0",
+            "shallowequal": "^1.1.0"
+          }
+        }
       }
     },
     "@ant-design/icons-svg": {
@@ -1409,6 +1429,11 @@
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@ctrl/tinycolor": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.2.0.tgz",
+      "integrity": "sha512-cP1tbXA1qJp/er2CJaO+Pbe38p7RlhV9WytUxUe79xj++Q6s/jKVvzJ9U2dF9f1/lZAdG+j94A38CsNR+uW4gw=="
     },
     "@emotion/is-prop-valid": {
       "version": "0.8.8",
@@ -9261,11 +9286,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
-    },
-    "tinycolor2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
+    "@ant-design/icons": "^4.3.0",
     "antd": "^4.2.5",
     "axios": "^0.19.2",
     "next": "^9.4.4",

--- a/pages/location/index.js
+++ b/pages/location/index.js
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import { Row, Col } from 'antd';
+import LocationTap from './tab';
+import MapContent from './location';
+
+const Location = () => {
+  return (
+    <>
+      <Row>
+        <div style={{ border: '1px solid black' }}>
+          홈 > 매장정보
+        </div>
+      </Row>
+      <Row>
+        <Col span={8}>
+          <LocationTap />
+          <div style={{ border: '1px solid black', height: '600px' }}>임시 정보</div>
+        </Col>
+        <Col span={10}>
+          <MapContent />
+        </Col>
+      </Row>
+    </>
+  );
+};
+
+export default Location;

--- a/pages/location/location.js
+++ b/pages/location/location.js
@@ -45,7 +45,7 @@ class MapContent extends Component {
   }
 
   render() {
-    return <MapContents id="Mymap" style={{ width: '90vh', height: '50vh' }} />;
+    return <MapContents id="Mymap" style={{ width: '60vh', height: '50vh' }} />;
   }
 }
 const MapContents = styled.div`

--- a/pages/location/tab.js
+++ b/pages/location/tab.js
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import { Menu } from 'antd';
+import { MailOutlined, AppstoreOutlined, SettingOutlined } from '@ant-design/icons';
+
+const { SubMenu } = Menu;
+
+const LocationTap = () => {
+  const [key, setKey] = useState('');
+
+  const handleClick = (e) => {
+    console.log('click ', e);
+    setKey(e.key);
+  };
+
+  return (
+    <Menu onClick={handleClick} selectedKeys={[key]} mode="horizontal">
+      <Menu.Item key="searchLoc" icon={<MailOutlined />}>
+        지역검색
+      </Menu.Item>
+      <Menu.Item key="storeInfo" icon={<MailOutlined />}>
+        매장정보
+      </Menu.Item>
+    </Menu>
+  );
+};
+
+export default LocationTap;


### PR DESCRIPTION
대략적인 레이아웃과 폴더구조를 잡아보았습니다.

1. 초기 레이아웃이여서 수정할 부분은 많겠으나 현재 레이아웃과 매장정보 폴더구조에 대한 리뷰 부탁드립니다.

2. [홈 > 매장정보](https://docs.google.com/presentation/d/1V8MYnucm8Wmu2FMn2hgWL35ZsStCoHiViNkH5HqgwKA/edit#slide=id.g8cb24942d8_0_47) 적힌 부분의 데이터는 나중에 전역 state로 관리하면 좋을거 같습니다.
예를들어 홈은 고정 그 다음부터 secondSegment, thirdSegment 이런식으로 다른 페이지에서도 공통적으로 사용할 수 있는 변수로 만들어서 전역 STATE로 사용할 것을 제안합니다.

![image](https://user-images.githubusercontent.com/34529589/100855736-dddb2a00-34cd-11eb-98b1-cb1bf8bf5f06.png)
