### PR TITLE
[매장검색] #18 매장정보 페이지 -> 지역 검색 -> 커스텀 드롭다운 훅 적용

### DIFF
--- a/hooks/useDropDown.js
+++ b/hooks/useDropDown.js
@@ -1,0 +1,14 @@
+import { useState, useCallback } from 'react';
+
+const useDropDown = (initialValue) => {
+  const [selectedValue, setSelectedValue] = useState(initialValue);
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const onClickSelect = useCallback((value) => {
+    setSelectedValue(value);
+  }, []);
+
+  return [selectedValue, onClickSelect, errorMsg, setErrorMsg];
+};
+
+export default useDropDown;

--- a/pages/location/index.js
+++ b/pages/location/index.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Row, Col } from 'antd';
 import LocationTap from './tab';
 import MapContent from './location';
+import LocationSearch from './locationSearch';
 
 const Location = () => {
   return (
@@ -14,7 +15,10 @@ const Location = () => {
       <Row>
         <Col span={8}>
           <LocationTap />
-          <div style={{ border: '1px solid black', height: '600px' }}>임시 정보</div>
+          <div style={{ border: '1px solid black', height: '600px' }}>
+            <LocationSearch />
+            임시 정보
+          </div>
         </Col>
         <Col span={10}>
           <MapContent />

--- a/pages/location/locationSearch.js
+++ b/pages/location/locationSearch.js
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import { Button, Select } from 'antd';
+import useDropDown from '../../hooks/useDropDown';
+
+const { Option } = Select;
+
+const LocationSearch = () => {
+  const [location1, onClickSelect1] = useDropDown('seoul');
+  const [location2, onClickSelect2] = useDropDown('junglang');
+
+  function onSubmit(value) {
+    console.log(location1, location2);
+  }
+
+  useEffect(() => {
+  }, []);
+
+  return (
+    <>
+      <Select defaultValue="서울" onChange={onClickSelect1}>
+        <Option value="seoul">서울</Option>
+        <Option value="busan">부산</Option>
+      </Select>
+      <Select defaultValue="중랑구" onChange={onClickSelect2}>
+        <Option value="junglang">중랑구</Option>
+        <Option value="nowon">노원구</Option>
+      </Select>
+      <Button onClick={onSubmit}>검색</Button>
+    </>
+  );
+};
+
+export default LocationSearch;


### PR DESCRIPTION
매장검색 메뉴의 지역검색에서 지역을 검색하는 드롭다운 UI 적용했습니다.

1) 커스텀 드롭다운 훅 적용
2) 드롭다운은 총 두개이며 첫째는 시, 두번째는 구 입니다.

기타) 공통으로 적용되는 AppLayout컴포넌트의 레이아웃이 현재 매장검색 메뉴에 영향을 줘 깨지고 있습니다. 이부분은 추후에 같이 수정이 필요합니다.